### PR TITLE
add no-url input parameter to subgraph-publish action

### DIFF
--- a/subgraph-publish/action.yml
+++ b/subgraph-publish/action.yml
@@ -25,6 +25,8 @@ inputs:
   # optional
   allow-invalid-routing-url:
     description: (Optional) Bypasses warnings and the prompt to confirm publish when the routing url is invalid in TTY environment
+  no-url:
+    description: (Optional) This is shorthand for `--routing-url "" --allow-invalid-routing-url`
 
   # common
   log:
@@ -43,6 +45,7 @@ runs:
         ARGS=(${{ inputs.graph-ref }} --name ${{ inputs.name }} --schema ${{ inputs.schema }} --skip-update-check)
         [ -n "${{ inputs.routing-url }}" ] && ARGS+=(--routing-url ${{ inputs.routing-url }})
         [ "${{ inputs.allow-invalid-routing-url }}" == "true" ] && ARGS+=(--allow-invalid-routing-url)
+        [ "${{ inputs.no-url }}" == "true" ] && ARGS+=(--no-url)
         [ -n "${{ inputs.log }}" ] && ARGS+=(--log ${{ inputs.log }})
         [ -n "${{ inputs.format }}" ] && ARGS+=(--format ${{ inputs.format }})
         [ -n "${{ inputs.client-timeout }}" ] && ARGS+=(--client-timeout ${{ inputs.client-timeout }})


### PR DESCRIPTION
This PR adds an optional input parameter to the `subgraph-publish` action, enabling the use of the `--no-url` option when publishing a subgraph schema to GraphOS. This feature will be particularly useful for Connectors because the `--no-url` option is recommended on [the getting started docs](https://www.apollographql.com/docs/guides/rest/publish#publish-your-graph) since they are server-free subgraphs.

![image](https://github.com/user-attachments/assets/4b40d0c9-a8af-464c-9a05-2b4c1f5d2cac)

## Test

I tested the updated action in this branch on a personal repository. I confirmed that running the action with `no-url: true` adds the `--no-url` option when executing `rover subgraph publish`.

- Test PR: https://github.com/DaleSeo/my-graph-qnyr67/pull/8
- Workflow Runs:
  - Without logging: https://github.com/DaleSeo/my-graph-qnyr67/actions/runs/14581563504/job/40899197217
  - With logging: https://github.com/DaleSeo/my-graph-qnyr67/actions/runs/14581579267/job/40899242581

![Shot 2025-04-21 at 17 19 45](https://github.com/user-attachments/assets/7ccb8c9b-f916-4365-9bcb-8afe351c2d70)
