### PR TITLE
docs: add the no-url option for subgraph publishing to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ This is a GitHub Action to perform the [`rover subgraph publish`](https://www.ap
 | `name` | The name of the subgraph | * | |
 | `schema` | The schema file to check | * | |
 | `routing-url` | Url of the running subgraph where a supergraph can route operations | [On first publish](https://www.apollographql.com/docs/rover/commands/subgraphs#subgraph-publish) | `<empty>` |
-| `allow-invalid-routing-url` | Bypasses warnings and the prompt to confirm publish when the routing url is invalid in TTY environment | | |
+| `allow-invalid-routing-url` | Bypasses warnings and the prompt to confirm publish when the routing url is invalid in TTY environment | |  `false`  |
+| `no-url`                    | Shorthand for setting an invalid `routing-url` and using `allow-invalid-routing-url`; this is predominantly used for Connectors-based subgraphs. |                                                                                                  |  `false`  |
 | `log` | Specify Rover's log level | | `info` |
 | `format` | Specify Rover's log format type [`plain`, `json`] | | `plain` |
 | `client-timeout` | Configure the timeout length (in seconds) when performing HTTP(S) requests | | `30` |


### PR DESCRIPTION
Just to reflect the changes made in PR #8 in the docs.